### PR TITLE
fix: don't send status

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -190,7 +190,6 @@ export default class Create extends SfCommand<CreateResponse> {
       new Ux({ jsonEnabled: this.jsonEnabled() }),
       this.flags.release as string
     );
-    record.Status = 'Approved, Scheduled';
     record.SM_Risk_Level__c = 'Low';
 
     const identity = await conn.identity();


### PR DESCRIPTION
fixes https://salesforce-internal.slack.com/archives/C011JSM3268/p1737019436994569
tldr; GUS changed the API to validate the absence of fields that weren't previously part of the v2 API but were allowed anyway.

[skip-validate-pr]

there might be other fields that throw errors