### PR TITLE
W-17239852 Add --test-environment flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ node_modules
 # os specific files
 .DS_Store
 .idea
+
+test.sh

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -20,7 +20,17 @@
     "command": "create",
     "flagAliases": ["configurationitem", "dryrun", "targetusername", "templateid", "u"],
     "flagChars": ["c", "i", "l", "o", "r"],
-    "flags": ["configuration-item", "dry-run", "flags-dir", "json", "location", "release", "target-org", "template-id"],
+    "flags": [
+      "configuration-item",
+      "dry-run",
+      "flags-dir",
+      "json",
+      "location",
+      "release",
+      "target-org",
+      "template-id",
+      "test-environment"
+    ],
     "plugin": "@salesforce/change-case-management"
   }
 ]

--- a/messages/create.md
+++ b/messages/create.md
@@ -9,3 +9,7 @@ change case template id
 # flags.configuration-item.summary
 
 Full path from the configuration item, ex: Salesforce.SF_Off_Core.DeveloperTools.NPM
+
+# flags.test-environment.summary
+
+Url to the test results for this change case. Will be added to the Change Case under "Automated Test Environment" (Test_Environment\_\_c)

--- a/messages/create.md
+++ b/messages/create.md
@@ -12,4 +12,4 @@ Full path from the configuration item, ex: Salesforce.SF_Off_Core.DeveloperTools
 
 # flags.test-environment.summary
 
-Url to the test results for this change case. Will be added to the Change Case under "Automated Test Environment" (Test_Environment\_\_c)
+Url to the test results for this change case. Will be added to the Change Case under "Automated Test Environment" (Test_Environment__c)

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -76,6 +76,10 @@ export default class Create extends SfCommand<CreateResponse> {
     }),
     release: releaseFlag,
     location: locationFlag,
+    'test-environment': Flags.string({
+      summary: messages.getMessage('flags.test-environment.summary'),
+      required: false,
+    }),
     'configuration-item': Flags.string({
       summary: messages.getMessage('flags.configuration-item.summary'),
       required: true,
@@ -185,6 +189,7 @@ export default class Create extends SfCommand<CreateResponse> {
     record.RecordTypeId = CHANGE_RECORD_TYPE_ID;
     record.SM_Source_Control_Location__c =
       this.flags.location?.toString() ?? (template.SM_Source_Control_Location__c as string);
+    record.Test_Environment__c = this.flags['test-environment'] ?? (template.Test_Environment__c as string);
     record.SM_Release__c = await retrieveOrCreateReleaseId(
       conn,
       new Ux({ jsonEnabled: this.jsonEnabled() }),

--- a/test/ctc.nut.ts
+++ b/test/ctc.nut.ts
@@ -97,7 +97,7 @@ describe('e2e', () => {
     let createResult: CreateResponse;
     it('create', () => {
       const result = execCmd<CreateResponse>(
-        `create --target-org ${session.hubOrg.username} --location ${repoUrl} --release ctc-nut --json`,
+        `create --target-org ${session.hubOrg.username} --location ${repoUrl} --test-environment ${repoUrl}/releases/tag/1.2.3 --release ctc-nut --json`,
         { ensureExitCode: 0 }
       ).jsonOutput?.result;
       assert(result);
@@ -106,6 +106,7 @@ describe('e2e', () => {
       createResult = result!;
       expect(result?.id !== 'NOT PRESENT BECAUSE DRY RUN');
       expect(result?.record.change.SM_Source_Control_Location__c).to.equal(repoUrl);
+      expect(result?.record.change.Test_Environment__c).to.equal(`${repoUrl}/releases/tag/1.2.3`);
     });
     describe('close', () => {
       it('dryrun close by location/release (verifies works with only env)', () => {


### PR DESCRIPTION
Part of the pipeline compliance work. We need to link from the Change Case to where the test were ran. 

This allows you to pass that in

Proof of this working:
https://gus.lightning.force.com/lightning/r/Case/500EE00001U9CTCYA3/view
Search for "Automated Test Environment"

[@W-17239852@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-17239852)
Also part of [@W-18023620@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18023620)