### PR TITLE
fix: avoid Node 24 unsettled top-level await crash in bin/run.js @W-23259920@

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 // eslint-disable-next-line node/shebang
-async function main() {
-  const { execute } = await import('@oclif/core');
-  await execute({ dir: import.meta.url });
-}
+import { execute } from '@oclif/core';
 
-await main();
+// No top-level `await`: on Node >=24.x a pending top-level await at process
+// exit is mis-flagged as "Detected unsettled top-level await" → the CLI exits
+// 13 with no stdout (nodejs/node#58398). `execute` already awaits
+// run + flush + Errors.handle internally, so fire-and-forget is sufficient.
+void execute({ dir: import.meta.url });


### PR DESCRIPTION
@W-23259920@

## What

Remove the top-level `await` from `bin/run.js` so the `sfchangecase` CLI stops crashing on Node >= 24.x.

```diff
-async function main() {
-  const { execute } = await import('@oclif/core');
-  await execute({ dir: import.meta.url });
-}
-
-await main();
+import { execute } from '@oclif/core';
+
+void execute({ dir: import.meta.url });
```

## Why

On Node, the process exits when the event loop empties; a top-level `await` that is still pending at that point is reported as `Warning: Detected unsettled top-level await` and the process exits with code **13** — see [nodejs/node#58398](https://github.com/nodejs/node/issues/58398) (and [#55468](https://github.com/nodejs/node/issues/55468)). Recent Node 24 builds surface this for oclif CLIs whose `bin/run.js` uses a top-level `await`; the Salesforce CLI hit the identical behavior ([forcedotcom/cli#3440](https://github.com/forcedotcom/cli/issues/3440), [#3586](https://github.com/forcedotcom/cli/issues/3586)).

Because `sfchangecase` is invoked by the shared CTC `ctcOpen` GitHub workflow, this breaks **Change Traffic Control for every consumer** whose runner runs a Node 24 build that exits on an unsettled top-level await (observed on `node/24.17.0`; not reproduced on `22.22.3` / `24.16.0` / `26.3.0`): the change case silently fails to open and **no error is surfaced** (empty `CTC_RESULT`, exit 13).

`execute()` from `@oclif/core` already awaits `run` + `flush` + `Errors.handle` internally, so calling it fire-and-forget (`void execute(...)`) removes the top-level-await trigger entirely while preserving exit codes and `--json` output. This matches oclif's ESM bin template, and the fix holds regardless of whether a given Node build is over-reporting or correctly enforcing.

## Verification

- `node bin/run.js --version` and `--help` → exit 0, correct output, no "unsettled top-level await" warning (local Node `v24.13.1`).
- `yarn compile` (tsc) passes; the smoke test runs the freshly built `lib`.

Caveat: I could not exercise `sfchangecase create` against the live CTC backend (needs org secrets) or repro on the exact `node/24.17.0`. The change is a CLI-bootstrap hardening with no behavioral change on a healthy Node.

## Note (unrelated, pre-existing)

`yarn lint` currently fails on `main` with 10 `header/header` errors — the license headers read `Copyright 2025` and the rule expects the current year. This is independent of this change (the affected `src`/`test` files are untouched here); a `yarn fix-license` run would clear it. I kept this PR scoped to the one-line CLI fix and did not bundle the year bump.
